### PR TITLE
Soporte de Include en ObtenerTodos del repositorio

### DIFF
--- a/BaezStone.MagicVilla.Api/Controllers/NumeroVillaController.cs
+++ b/BaezStone.MagicVilla.Api/Controllers/NumeroVillaController.cs
@@ -34,7 +34,9 @@ public class NumeroVillaController : ControllerBase
         {
             _logger.LogInformation("Solicitud GET api/NumeroVilla iniciada.");
 
-            var numeroVillas = await _numeroVillaRepo.ObtenerTodosConVilla();
+            //var numeroVillas = await _numeroVillaRepo.ObtenerTodosConVilla();
+
+            var numeroVillas = await _numeroVillaRepo.ObtenerTodos(includeProperties: "Villa");
 
             var numeroVillasDto = numeroVillas.Adapt<List<NumeroVillaDto>>();
 

--- a/BaezStone.MagicVilla.Api/Repositorio/IRepositorio/IRepositorio.cs
+++ b/BaezStone.MagicVilla.Api/Repositorio/IRepositorio/IRepositorio.cs
@@ -6,7 +6,7 @@ public interface IRepositorio<T>
     where T : class
 {
     Task Crear(T entidad);
-    Task<List<T>> ObtenerTodos(Expression<Func<T, bool>>? filtro = null);
+    Task<List<T>> ObtenerTodos(Expression<Func<T, bool>>? filtro = null, string? includeProperties = null);
     Task<T?> Obtener(Expression<Func<T, bool>>? filtro = null, bool tracked = true);
     Task Remover(T entidad);
     Task Grabar();

--- a/BaezStone.MagicVilla.Api/Repositorio/Repositorio.cs
+++ b/BaezStone.MagicVilla.Api/Repositorio/Repositorio.cs
@@ -31,19 +31,39 @@ public class Repositorio<T> : IRepositorio<T>
     public async Task<T?> Obtener(Expression<Func<T, bool>>? filtro = null, bool tracked = true)
     {
         IQueryable<T> query = tracked ? dbSet : dbSet.AsNoTracking();
-        
+
         return filtro is null
                ? await query.FirstOrDefaultAsync()
                : await query.FirstOrDefaultAsync(filtro);
     }
 
-    public Task<List<T>> ObtenerTodos(Expression<Func<T, bool>>? filtro = null)
+    //public Task<List<T>> ObtenerTodos(Expression<Func<T, bool>>? filtro = null)
+    //{
+    //    IQueryable<T> query = dbSet;
+
+    //    return filtro is null
+    //           ? query.ToListAsync()
+    //           : query.Where(filtro).ToListAsync();
+    //}
+
+    public async Task<List<T>> ObtenerTodos(Expression<Func<T, bool>>? filtro = null,
+        string? includeProperties = null)
     {
         IQueryable<T> query = dbSet;
 
-        return filtro is null
-               ? query.ToListAsync()
-               : query.Where(filtro).ToListAsync();
+        if (filtro != null)
+            query = query.Where(filtro);
+
+        if (!string.IsNullOrEmpty(includeProperties))
+        {
+            foreach (var includeProp 
+                in includeProperties.Split(',', StringSplitOptions.RemoveEmptyEntries))
+            {
+                query = query.Include(includeProp);
+            }
+        }
+
+        return await query.ToListAsync();
     }
 
     public async Task Remover(T entidad)


### PR DESCRIPTION
Soporte de Include en ObtenerTodos del repositorio

Se añadió el parámetro opcional includeProperties a ObtenerTodos en IRepositorio y Repositorio para permitir la carga ansiosa de entidades relacionadas. Se actualizó NumeroVillaController para incluir datos de Villa al consultar NumeroVilla. Se comentaron las versiones anteriores del método sin soporte de Include.